### PR TITLE
Fix covar keyword

### DIFF
--- a/KinMS_mcmc.pro
+++ b/KinMS_mcmc.pro
@@ -1,5 +1,5 @@
 
-function KinMS_mcmc,param,_extra=_extra,iters=iters,outputll=outputll,finaloutput=finaloutput,silent=silent,log=log
+function KinMS_mcmc,param,_extra=_extra,iters=iters,outputll=outputll,finaloutput=finaloutput,silent=silent,log=log,covar=covar
   COMMON KinMS_COMMON, fdata,obspars
   !EXCEPT = 0
   ;;;;;;;;;;;;;;;
@@ -29,7 +29,7 @@ function KinMS_mcmc,param,_extra=_extra,iters=iters,outputll=outputll,finaloutpu
   
   ;;;;;Call MCMC
 
-  mcmc_new,param,iters,25l*total(param.changeable),300,1l,model="mkkinms_model",likelihood="mcmc_new_likelihood",plotchains=plotit,silent=silent,outputll=outputll,outputvalue=outputvalue,log=log
+  mcmc_new,param,iters,25l*total(param.changeable),300,1l,model="mkkinms_model",likelihood="mcmc_new_likelihood",plotchains=plotit,silent=silent,outputll=outputll,outputvalue=outputvalue,log=log,covar=covar
 
   save,param,outputvalue,obspars,outputll,filename=finaloutput+"_parsave.sav"
   ;;;;;;


### PR DESCRIPTION
The covar keyword was not explicitly passed by this wrapper function to mcmc_new. This change adds an explicit keyword to both the function and the mcmc_new call.